### PR TITLE
refactor: improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,16 +16,15 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "dotenv",
- "lazy_static",
  "markdown_to_text",
  "milli",
  "mime_guess",
  "rand_core 0.6.3",
- "regex",
  "rust-embed",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4"
-
 diesel = { version = "1.4.4", features = ["postgres", "r2d2", "chrono", "uuidv07"] }
 dotenv = "0.15.0"
 serde = { version = "1", features = ["derive"] }
@@ -26,5 +25,4 @@ diesel_migrations = "1.4"
 actix-cors = "0.6"
 uuid = { version = "0.8", features = ["v4", "serde"] }
 blake3 = "1.3.1"
-regex = "1"
-lazy_static = "1.4.0"
+thiserror = "1.0.31"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,6 @@ extern crate diesel;
 extern crate dotenv;
 #[macro_use]
 extern crate diesel_migrations;
-#[macro_use]
-extern crate lazy_static;
 
 use actix_cors::Cors;
 use actix_identity::{CookieIdentityPolicy, IdentityService};
@@ -92,7 +90,7 @@ async fn main() -> std::io::Result<()> {
                         web::scope("/feedback")
                             .service(routes::feedback::post_feedback) // POST /
                             .service(routes::feedback::get_feedback_from_post) // GET /post?limit=Int&post_id=UUID
-                            .service(routes::feedback::get_feedback_list) // GET /?limit=Int
+                            .service(routes::feedback::get_feedback_list), // GET /?limit=Int
                     ),
             )
             .service(
@@ -101,7 +99,7 @@ async fn main() -> std::io::Result<()> {
                     .service(routes::dashboard::dist),
             )
     })
-        .bind(("0.0.0.0", 8080))?
-        .run()
-        .await
+    .bind(("0.0.0.0", 8080))?
+    .run()
+    .await
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,4 +1,5 @@
-use crate::actions::DbError;
+use crate::actions::post_to_listpost;
+use crate::actions::AppError;
 use crate::models;
 use crate::models::ListPosts;
 use crate::schema::posts::dsl::{created_at, posts, slug};
@@ -13,7 +14,6 @@ use milli::update::{IndexDocuments, IndexDocumentsConfig, IndexerConfig};
 use milli::Search;
 use serde::{Deserialize, Serialize};
 use std::io::Cursor;
-use crate::actions::post_to_listpost;
 
 extern crate milli;
 
@@ -34,7 +34,7 @@ fn clean_html(input: &str) -> Result<String, String> {
     Err("Could not find text".to_string())
 }
 */
-pub fn search(term: &str, conn: &PgConnection) -> Result<Vec<ListPosts>, DbError> {
+pub fn search(term: &str, conn: &PgConnection) -> Result<Vec<ListPosts>, AppError> {
     let path = tempfile::tempdir().unwrap();
     let mut options = EnvOpenOptions::new();
     options.map_size(10 * 1024 * 1024); // 10 MB
@@ -101,8 +101,5 @@ pub fn search(term: &str, conn: &PgConnection) -> Result<Vec<ListPosts>, DbError
         .order_by(created_at.desc())
         .load::<models::Post>(conn)
         .unwrap();
-    Ok(res
-        .into_iter()
-        .map(post_to_listpost)
-        .collect())
+    Ok(res.into_iter().map(post_to_listpost).collect())
 }


### PR DESCRIPTION
This improves the error handling of methods that previously returned a generic `DbError`.
It now returns a concrete `AppError` enum, whose variants wrap a concrete third party error (e.g. by diesel, argon2 etc.).

This makes it much easier to decide, which concrete actix_web error needs to be returned.

All this is made possible by the rather elegant `thiserror` crate:
https://docs.rs/thiserror/latest/thiserror

Note that there is still room for improvement, though:
for a lot of errors that can happen in diesel or elsewhere, we currently return a rather generic `ErrorInternalServerError` error.

new deps: thiserror => enables much better error handling
removed deps: lazy_static, regex => not needed anymore

------------------------------------------------------

Please do not wonder, why there are so many other unrelated changes. These are primarily formatting changes, because I use rust-analyzer with auto formatting in VS Code.
I can highly recommend auto format on save. :wink: 